### PR TITLE
Add DPG Badge to Go.Data README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://github.com/WorldHealthOrganization/godata/blob/master/docs/assets/godata-logo.png)
 
-# Welcome to the Go.Data Site! 
+# Welcome to the Go.Data Site! [![DPG Badge](https://img.shields.io/badge/Verified-DPG-3333AB?logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzEiIGhlaWdodD0iMzMiIHZpZXdCb3g9IjAgMCAzMSAzMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0LjIwMDggMjEuMzY3OEwxMC4xNzM2IDE4LjAxMjRMMTEuNTIxOSAxNi40MDAzTDEzLjk5MjggMTguNDU5TDE5LjYyNjkgMTIuMjExMUwyMS4xOTA5IDEzLjYxNkwxNC4yMDA4IDIxLjM2NzhaTTI0LjYyNDEgOS4zNTEyN0wyNC44MDcxIDMuMDcyOTdMMTguODgxIDUuMTg2NjJMMTUuMzMxNCAtMi4zMzA4MmUtMDVMMTEuNzgyMSA1LjE4NjYyTDUuODU2MDEgMy4wNzI5N0w2LjAzOTA2IDkuMzUxMjdMMCAxMS4xMTc3TDMuODQ1MjEgMTYuMDg5NUwwIDIxLjA2MTJMNi4wMzkwNiAyMi44Mjc3TDUuODU2MDEgMjkuMTA2TDExLjc4MjEgMjYuOTkyM0wxNS4zMzE0IDMyLjE3OUwxOC44ODEgMjYuOTkyM0wyNC44MDcxIDI5LjEwNkwyNC42MjQxIDIyLjgyNzdMMzAuNjYzMSAyMS4wNjEyTDI2LjgxNzYgMTYuMDg5NUwzMC42NjMxIDExLjExNzdMMjQuNjI0MSA5LjM1MTI3WiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+Cg==)](https://digitalpublicgoods.net/r/godata)
 
 This repository serves as an [umbrella site](https://worldhealthorganization.github.io/godata/) to gear the community towards existing technical documentation, resources, and open source components developed by and for the Go.Data community worldwide, particularly in the area of Analytics and Interoperability.
 


### PR DESCRIPTION
This PR includes the new DPG badge in the README file following [the guide](https://github.com/DPGAlliance/dpg-resources/blob/main/docs/dpg-badge-usage.md) and links to Go.Data's new profile page URL on the [DPG Registry](https://digitalpublicgoods.net/registry). Please feel free to adjust the position. Thanks!