### PR TITLE
Add DPG badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ You can find all additional repos connected to the Go.Data tool in the overarchi
 
 [Go.Data](https://www.who.int/tools/godata) is a software for contact tracing and outbreak response developed by WHO in collaboration with partners in the Global Outbreak Alert and Response Network (GOARN). Go.Data focuses on case and contact data including laboratory data, hospitalizaton and other variables collected through investigation forms that can be configured across settings and disease types. It generates contact follow-up lists and viusalisation of chains of tranmission. It is currently in use in over 60 countries / territories, and in over 80 different institutions at the national or subnational level.
 
+[![DPG Badge](https://img.shields.io/badge/Verified-DPG-3333AB?logo=data:image/svg%2bxml;base64,PHN2ZyB3aWR0aD0iMzEiIGhlaWdodD0iMzMiIHZpZXdCb3g9IjAgMCAzMSAzMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE0LjIwMDggMjEuMzY3OEwxMC4xNzM2IDE4LjAxMjRMMTEuNTIxOSAxNi40MDAzTDEzLjk5MjggMTguNDU5TDE5LjYyNjkgMTIuMjExMUwyMS4xOTA5IDEzLjYxNkwxNC4yMDA4IDIxLjM2NzhaTTI0LjYyNDEgOS4zNTEyN0wyNC44MDcxIDMuMDcyOTdMMTguODgxIDUuMTg2NjJMMTUuMzMxNCAtMi4zMzA4MmUtMDVMMTEuNzgyMSA1LjE4NjYyTDUuODU2MDEgMy4wNzI5N0w2LjAzOTA2IDkuMzUxMjdMMCAxMS4xMTc3TDMuODQ1MjEgMTYuMDg5NUwwIDIxLjA2MTJMNi4wMzkwNiAyMi44Mjc3TDUuODU2MDEgMjkuMTA2TDExLjc4MjEgMjYuOTkyM0wxNS4zMzE0IDMyLjE3OUwxOC44ODEgMjYuOTkyM0wyNC44MDcxIDI5LjEwNkwyNC42MjQxIDIyLjgyNzdMMzAuNjYzMSAyMS4wNjEyTDI2LjgxNzYgMTYuMDg5NUwzMC42NjMxIDExLjExNzdMMjQuNjI0MSA5LjM1MTI3WiIgZmlsbD0id2hpdGUiLz4KPC9zdmc+Cg==)](https://www.digitalpublicgoods.net/r/godata)
+
 ## Components
 
 Go.Data utilizes of the following tools and components:


### PR DESCRIPTION
This PR includes the new DPG badge in the README file, following [the guide](https://github.com/DPGAlliance/dpg-resources/blob/main/docs/dpg-badge-usage.md), and links to Go.Data's profile page on the [DPG Registry](https://www.digitalpublicgoods.net/registry).